### PR TITLE
Update package references and ignore JetBrains project metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ obj/
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+# Ignore full JetBrains project metadata directory
+.idea/
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/ExcelToAppleCalendar.App.Tests/ExcelToAppleCalendar.App.Tests.csproj
+++ b/ExcelToAppleCalendar.App.Tests/ExcelToAppleCalendar.App.Tests.csproj
@@ -10,19 +10,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="FakeItEasy" Version="9.0.1" />
         <PackageReference Include="FluentAssertions" Version="[7.0.0,8.0.0)" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="NUnit" Version="4.5.1" />
         <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ExcelToAppleCalendar.App/ExcelToAppleCalendar.App.csproj
+++ b/ExcelToAppleCalendar.App/ExcelToAppleCalendar.App.csproj
@@ -24,9 +24,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
     </ItemGroup>
 
 </Project>

--- a/ExcelToAppleCalendar.Library.Tests/ExcelToAppleCalendar.Library.Tests.csproj
+++ b/ExcelToAppleCalendar.Library.Tests/ExcelToAppleCalendar.Library.Tests.csproj
@@ -10,19 +10,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="FakeItEasy" Version="9.0.1" />
         <PackageReference Include="FluentAssertions" Version="[7.0.0,8.0.0)" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="NUnit" Version="4.5.1" />
         <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ExcelToAppleCalendar.Library/ExcelToAppleCalendar.Library.csproj
+++ b/ExcelToAppleCalendar.Library/ExcelToAppleCalendar.Library.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="EPPlus" Version="8.5.0" />
+        <PackageReference Include="EPPlus" Version="8.5.3" />
         <PackageReference Include="Ical.Net" Version="5.2.1" />
     </ItemGroup>
 


### PR DESCRIPTION
This pull request updates several NuGet package dependencies across the solution to keep the codebase current with the latest features and bug fixes. The changes focus on upgrading both core library dependencies and test-related packages.

Dependency upgrades:

**Test project dependency updates:**
- Upgraded `coverlet.collector` to version 10.0.0, `Microsoft.NET.Test.Sdk` to 18.4.0, and `NUnit3TestAdapter` to 6.2.0 in both `ExcelToAppleCalendar.App.Tests` and `ExcelToAppleCalendar.Library.Tests` to ensure compatibility with the latest test tooling and coverage reporting. [[1]](diffhunk://#diff-6fde14ff3036513ab3bd896ead80e6098d93f5e1b355ba40a13a24e49f6a9a36L13-R25) [[2]](diffhunk://#diff-2d80c015405ba745d14a38d0f5d6163aa6f23a3b9ede8b4c24ec5ce9fa48d980L13-R25)

**Core library dependency updates:**
- Upgraded `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.DependencyInjection`, and `Microsoft.Extensions.Hosting` from version 10.0.5 to 10.0.6 in `ExcelToAppleCalendar.App` for improved stability and bug fixes.
- Upgraded `EPPlus` from version 8.5.0 to 8.5.3 in `ExcelToAppleCalendar.Library` for enhanced Excel file handling and bug fixes.