### PR TITLE
Update NuGet package references

### DIFF
--- a/ExcelToAppleCalendar.App.Tests/ExcelToAppleCalendar.App.Tests.csproj
+++ b/ExcelToAppleCalendar.App.Tests/ExcelToAppleCalendar.App.Tests.csproj
@@ -16,9 +16,9 @@
         </PackageReference>
         <PackageReference Include="FakeItEasy" Version="9.0.1" />
         <PackageReference Include="FluentAssertions" Version="[7.0.0,8.0.0)" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-        <PackageReference Include="NUnit" Version="4.5.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+        <PackageReference Include="NUnit" Version="4.6.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/ExcelToAppleCalendar.App/ExcelToAppleCalendar.App.csproj
+++ b/ExcelToAppleCalendar.App/ExcelToAppleCalendar.App.csproj
@@ -24,9 +24,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     </ItemGroup>
 
 </Project>

--- a/ExcelToAppleCalendar.Library.Tests/ExcelToAppleCalendar.Library.Tests.csproj
+++ b/ExcelToAppleCalendar.Library.Tests/ExcelToAppleCalendar.Library.Tests.csproj
@@ -16,9 +16,9 @@
         </PackageReference>
         <PackageReference Include="FakeItEasy" Version="9.0.1" />
         <PackageReference Include="FluentAssertions" Version="[7.0.0,8.0.0)" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-        <PackageReference Include="NUnit" Version="4.5.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+        <PackageReference Include="NUnit" Version="4.6.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/ExcelToAppleCalendar.Library/ExcelToAppleCalendar.Library.csproj
+++ b/ExcelToAppleCalendar.Library/ExcelToAppleCalendar.Library.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="EPPlus" Version="8.5.3" />
-        <PackageReference Include="Ical.Net" Version="5.2.1" />
+        <PackageReference Include="EPPlus" Version="8.5.4" />
+        <PackageReference Include="Ical.Net" Version="5.2.2" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates all outdated NuGet packages across the solution.

| Package | Old | New |
|---|---|---|
| EPPlus | 8.5.3 | 8.5.4 |
| Ical.Net | 5.2.1 | 5.2.2 |
| FluentAssertions | `[7.0.0,8.0.0)` | kept (license constraint) |
| Microsoft.NET.Test.Sdk | 18.4.0 | 18.5.1 |
| NUnit | 4.5.1 | 4.6.0 |
| NUnit.Analyzers | 4.12.0 | 4.13.0 |
| Microsoft.Extensions.* | 10.0.6 | 10.0.8 |

> FluentAssertions is intentionally kept below v8 due to its license change.